### PR TITLE
Update "Asset Register" page to point to the new up-to-date Asset Reg…

### DIFF
--- a/resources/views/equipment/assets/view.blade.php
+++ b/resources/views/equipment/assets/view.blade.php
@@ -10,5 +10,5 @@
     <iframe width="100%"
             height="700"
             frameborder="0"
-            src="https://docs.google.com/spreadsheets/d/19oMod3uCJp51h_BfpCy0sprKueOWOxBXSmI1PcIm19I/pubhtml?widget=false&headers=false&chrome=false&gid=0"></iframe>
+            src="https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRBIJLyKO--ffboCd90BXWBD95DZm99cXXqi9eSnzPkoCMeMIilnRC81udAtD3ghbF4zt5bzeqDLGQb/pubhtml?widget=true&amp;headers=false"></iframe>
 @endsection


### PR DESCRIPTION
…ister

### Issue summary

The spreadsheet shown on the "Asset Register" section of the BTS website is currently very much out of date. A new Asset Register spreadsheet has been created, and significant efforts to populate it with our touring shed and under rake stock (including Standing Rig) are underway, with the ALT+underrake stock already catalogued, and an audit of the Shed scheduled for next week. It would therefore make sense for the current "Asset Register" website page to point to this new, up-to-date, register.

### Work included

The contents of the <iframe> element in the website-main/resources/views/equipment/assets/view.blade.php file has been updated to point to the published URL of the new Google Docs spreadsheet, which per my understanding should allow the "Asset Register" page to display the new up-to-date spreadsheet.

### Testing

The new URL, generated from the "Publish to Web" Google Docs function, has been tested by entering it directly into a browser, to ensure that it points to the correct spreadsheet.
